### PR TITLE
Implement global 401 handling

### DIFF
--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -16,6 +16,7 @@ import Typography from "@mui/material/Typography";
 import type { Artifact } from "@/types/artifact"; // Sua interface Artifact
 import { ArtifactCard } from "@/components/dashboard/artifacts/artifact-card"; // Seu componente ArtifactCard
 import { CreateArtifactModal } from "@/components/artifacts/create-artifact-modal";
+import { apiFetch } from "@/lib/api";
 
 // Componente Placeholder para adicionar artefatos
 interface CardPlaceholderProps {
@@ -60,21 +61,7 @@ export default function Dashboard(): React.JSX.Element {
     setLoading(true);
     setError(null);
     try {
-      const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-      const token = localStorage.getItem("token");
-
-      if (!token) {
-        setError("Token de autenticação não encontrado. Faça login.");
-        setLoading(false);
-        return;
-      }
-
-      const response = await fetch(`${API_URL}/api/v1/artifacts`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-      });
+      const response = await apiFetch("/artifacts");
 
       if (!response.ok) {
         const errorData = await response.json();

--- a/src/app/dashboard/users/page.tsx
+++ b/src/app/dashboard/users/page.tsx
@@ -18,6 +18,7 @@ import type { User } from "@/components/dashboard/user/users-table";
 import { UserCreateModal, NewUserData } from "@/components/dashboard/user/user-create-modal";
 import { UserEditModal, UserUpdateData } from "@/components/dashboard/user/user-edit-modal";     // Novo: Modal de Edição
 import { UserDeleteConfirmModal } from "@/components/dashboard/user/user-delete-confirm-modal"; // Novo: Modal de Confirmação de Exclusão
+import { apiFetch } from "@/lib/api";
 
 
 // Metadata para a página (ajuste conforme a estrutura do seu projeto Next.js)
@@ -61,21 +62,7 @@ export default function Page(): React.JSX.Element {
     setLoading(true);
     setError(null);
     try {
-      const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-      const token = localStorage.getItem('token');
-
-      if (!token) {
-        setError("Token de autenticação não encontrado. Faça login.");
-        setLoading(false);
-        return;
-      }
-
-      const response = await fetch(`${API_URL}/api/v1/users/`, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      });
+      const response = await apiFetch("/users/");
 
       if (!response.ok) {
         const errorData = await response.json();
@@ -138,17 +125,9 @@ export default function Page(): React.JSX.Element {
     setCreatingUser(true);
     setCreateUserError(null);
     try {
-      const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-      const token = localStorage.getItem('token');
-
-      if (!token) {
-        throw new Error("Token de autenticação não encontrado. Faça login.");
-      }
-
-      const response = await fetch(`${API_URL}/api/v1/auth/signup`, {
+      const response = await apiFetch("/auth/signup", {
         method: 'POST',
         headers: {
-          'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(userData),
@@ -186,18 +165,9 @@ export default function Page(): React.JSX.Element {
     setUpdatingUser(true);
     setUpdateUserError(null);
     try {
-      const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-      const token = localStorage.getItem('token');
-
-      if (!token) {
-        throw new Error("Token de autenticação não encontrado. Faça login.");
-      }
-
-      // Endpoint para atualização de usuário (ajuste se for diferente no seu backend)
-      const response = await fetch(`${API_URL}/api/v1/users/${userId}`, {
-        method: 'PUT', // Ou PATCH, dependendo da sua API
+      const response = await apiFetch(`/users/${userId}`, {
+        method: 'PUT',
         headers: {
-          'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(userData),
@@ -235,19 +205,8 @@ export default function Page(): React.JSX.Element {
     setConfirmingDelete(true);
     setDeleteUserError(null);
     try {
-      const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-      const token = localStorage.getItem('token');
-
-      if (!token) {
-        throw new Error("Token de autenticação não encontrado. Faça login.");
-      }
-
-      // Endpoint para exclusão de usuário (ajuste se for diferente no seu backend)
-      const response = await fetch(`${API_URL}/api/v1/users/${userId}`, {
+      const response = await apiFetch(`/users/${userId}`, {
         method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
       });
 
       if (!response.ok) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { paths } from "@/paths";
+import { logout } from "@/lib/auth/logout";
 
 // Base URL for the API. Allows overriding via environment variable.
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -23,13 +23,9 @@ export async function apiFetch(path: string, options: ApiOptions = {}): Promise<
 
 	const res = await fetch(`${API_BASE}${path}`, { ...rest, headers: initHeaders });
 
-	if (res.status === 401) {
-		localStorage.removeItem("token");
-
-		if (globalThis.window !== undefined) {
-			globalThis.location.href = paths.auth.signIn;
-		}
-	}
+        if (res.status === 401) {
+                logout();
+        }
 
 	return res;
 }

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -2,6 +2,7 @@
 
 import type { User } from "@/types/user";
 import { apiFetch } from "@/lib/api";
+import { logout } from "@/lib/auth/logout";
 
 const user = {
 	id: "USR-000",
@@ -89,11 +90,11 @@ class AuthClient {
 		return { data: user };
 	}
 
-	async signOut(): Promise<{ error?: string }> {
-		localStorage.removeItem("token");
+        async signOut(): Promise<{ error?: string }> {
+                logout();
 
-		return {};
-	}
+                return {};
+        }
 }
 
 export const authClient = new AuthClient();

--- a/src/lib/auth/logout.ts
+++ b/src/lib/auth/logout.ts
@@ -1,0 +1,18 @@
+import { paths } from "@/paths";
+
+let loggingOut = false;
+
+export function logout(): void {
+  if (loggingOut || typeof window === "undefined") {
+    return;
+  }
+  loggingOut = true;
+
+  try {
+    localStorage.removeItem("token");
+    sessionStorage.removeItem("token");
+    document.cookie = "token=; Max-Age=0; path=/";
+  } finally {
+    window.location.href = paths.auth.signIn;
+  }
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 
-import { paths } from "@/paths";
+import { logout } from "@/lib/auth/logout";
 
 /**
  * Custom Axios request configuration allowing a boolean `withAuth` property
@@ -37,14 +37,10 @@ api.interceptors.request.use((config) => {
 // Add a response interceptor to handle unauthorized responses.
 api.interceptors.response.use(
 	(response: AxiosResponse): AxiosResponse => response,
-	(error) => {
-		if (error.response && error.response.status === 401) {
-			localStorage.removeItem("token");
-
-			if (globalThis.window !== undefined) {
-				globalThis.location.href = paths.auth.signIn;
-			}
-		}
+        (error) => {
+                if (error.response && error.response.status === 401) {
+                        logout();
+                }
 
 		return Promise.reject(error);
 	}


### PR DESCRIPTION
## Summary
- centralize logout in `logout` utility
- handle 401 responses in fetch and axios using the logout helper
- redirect after sign out using the same helper
- use `apiFetch` across dashboard pages to ensure 401 interception

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686acb52fe608328b7af776d904fd067