### PR TITLE
Add artifact editing modal

### DIFF
--- a/src/app/dashboard/dashboard.tsx
+++ b/src/app/dashboard/dashboard.tsx
@@ -16,6 +16,7 @@ import Typography from "@mui/material/Typography";
 import type { Artifact } from "@/types/artifact"; // Sua interface Artifact
 import { ArtifactCard } from "@/components/dashboard/artifacts/artifact-card"; // Seu componente ArtifactCard
 import { CreateArtifactModal } from "@/components/artifacts/create-artifact-modal";
+import { EditArtifactModal } from "@/components/artifacts/edit-artifact-modal";
 import { apiFetch } from "@/lib/api";
 
 // Componente Placeholder para adicionar artefatos
@@ -55,6 +56,7 @@ export default function Dashboard(): React.JSX.Element {
   const [error, setError] = React.useState<string | null>(null);
 
   const [openCreateModal, setOpenCreateModal] = React.useState<boolean>(false);
+  const [selectedArtifact, setSelectedArtifact] = React.useState<Artifact | null>(null);
 
   // Busca os artefatos do backend
   const fetchArtifacts = React.useCallback(async () => {
@@ -118,9 +120,13 @@ export default function Dashboard(): React.JSX.Element {
 								<Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>Rascunho ({draft.length})</Typography>
 								<Button size="small" sx={{ minWidth: 'unset', p: '4px', borderRadius: '50%' }}>...</Button> {/* Botão de opções */}
 							</Box>
-							{draft.map((artifact) => (
-								<ArtifactCard key={artifact.id} artifact={artifact} />
-							))}
+                                                        {draft.map((artifact) => (
+                                                                <ArtifactCard
+                                                                        key={artifact.id}
+                                                                        artifact={artifact}
+                                                                        onClick={() => setSelectedArtifact(artifact)}
+                                                                />
+                                                        ))}
                                                         <CardPlaceholder onClick={() => setOpenCreateModal(true)} />
 						</Stack>
 					</Grid>
@@ -135,9 +141,13 @@ export default function Dashboard(): React.JSX.Element {
 								<Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>Em Revisão ({inReview.length})</Typography>
 								<Button size="small" sx={{ minWidth: 'unset', p: '4px', borderRadius: '50%' }}>...</Button>
 							</Box>
-							{inReview.map((artifact) => (
-								<ArtifactCard key={artifact.id} artifact={artifact} />
-							))}
+                                                        {inReview.map((artifact) => (
+                                                                <ArtifactCard
+                                                                        key={artifact.id}
+                                                                        artifact={artifact}
+                                                                        onClick={() => setSelectedArtifact(artifact)}
+                                                                />
+                                                        ))}
                                                         <CardPlaceholder onClick={() => setOpenCreateModal(true)} />
 						</Stack>
 					</Grid>
@@ -152,9 +162,13 @@ export default function Dashboard(): React.JSX.Element {
 								<Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>Publicado ({published.length})</Typography>
 								<Button size="small" sx={{ minWidth: 'unset', p: '4px', borderRadius: '50%' }}>...</Button>
 							</Box>
-							{published.map((artifact) => (
-								<ArtifactCard key={artifact.id} artifact={artifact} />
-							))}
+                                                        {published.map((artifact) => (
+                                                                <ArtifactCard
+                                                                        key={artifact.id}
+                                                                        artifact={artifact}
+                                                                        onClick={() => setSelectedArtifact(artifact)}
+                                                                />
+                                                        ))}
                                                         <CardPlaceholder onClick={() => setOpenCreateModal(true)} />
 						</Stack>
 					</Grid>
@@ -163,6 +177,16 @@ export default function Dashboard(): React.JSX.Element {
                         <CreateArtifactModal
                                 open={openCreateModal}
                                 onClose={() => setOpenCreateModal(false)}
+                        />
+                        <EditArtifactModal
+                                open={Boolean(selectedArtifact)}
+                                artifact={selectedArtifact}
+                                onClose={() => setSelectedArtifact(null)}
+                                onSaved={(updated) =>
+                                        setArtifacts((prev) =>
+                                                prev.map((a) => (a.id === updated.id ? updated : a))
+                                        )
+                                }
                         />
                 </Stack>
         );

--- a/src/components/artifacts/edit-artifact-modal.tsx
+++ b/src/components/artifacts/edit-artifact-modal.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import * as React from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Alert,
+  CircularProgress,
+} from "@mui/material";
+
+import type { Artifact } from "@/types/artifact";
+import api, { ApiRequestConfig } from "@/utils/api";
+
+export interface EditArtifactModalProps {
+  artifact: Artifact | null;
+  open: boolean;
+  onClose: () => void;
+  onSaved?: (artifact: Artifact) => void;
+}
+
+const artifactTypes = ["script", "video", "slide"] as const;
+const artifactStatuses = ["draft", "in_review", "published"] as const;
+const reviewTypes = ["text", "url"] as const;
+
+export function EditArtifactModal({
+  artifact,
+  open,
+  onClose,
+  onSaved,
+}: EditArtifactModalProps): React.JSX.Element {
+  const [name, setName] = React.useState("");
+  const [type, setType] = React.useState<typeof artifactTypes[number]>("script");
+  const [status, setStatus] = React.useState<typeof artifactStatuses[number]>("draft");
+  const [reviewType, setReviewType] = React.useState<typeof reviewTypes[number]>("text");
+  const [review, setReview] = React.useState<string>("");
+  const [link, setLink] = React.useState<string>("");
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (artifact && open) {
+      setName(artifact.name ?? "");
+      setType(artifact.type as typeof artifactTypes[number]);
+      setStatus(artifact.status as typeof artifactStatuses[number]);
+      setReviewType(artifact.review_type as typeof reviewTypes[number]);
+      setReview(artifact.review ?? "");
+      setLink(artifact.link ?? "");
+      setError(null);
+    }
+  }, [artifact, open]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!artifact) return;
+    if (!name.trim()) {
+      setError("Nome é obrigatório.");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const { data } = await api.put(`/artifacts/${artifact.id}`, {
+        name,
+        type,
+        status,
+        review_type: reviewType,
+        review,
+        link,
+      }, { withAuth: true } as ApiRequestConfig);
+      if (onSaved) {
+        onSaved(data as Artifact);
+      }
+      onClose();
+    } catch (error_) {
+      console.error(error_);
+      setError(error_ instanceof Error ? error_.message : "Erro ao atualizar artefato");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Editar Artefato</DialogTitle>
+      <form onSubmit={handleSubmit}>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Nome"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              fullWidth
+            />
+            <Select value={type} onChange={(e) => setType(e.target.value as typeof artifactTypes[number])} fullWidth>
+              {artifactTypes.map((option) => (
+                <MenuItem key={option} value={option}>
+                  {option}
+                </MenuItem>
+              ))}
+            </Select>
+            <Select value={status} onChange={(e) => setStatus(e.target.value as typeof artifactStatuses[number])} fullWidth>
+              {artifactStatuses.map((option) => (
+                <MenuItem key={option} value={option}>
+                  {option.replace("_", " ")}
+                </MenuItem>
+              ))}
+            </Select>
+            <Select value={reviewType} onChange={(e) => setReviewType(e.target.value as typeof reviewTypes[number])} fullWidth>
+              {reviewTypes.map((option) => (
+                <MenuItem key={option} value={option}>
+                  {option}
+                </MenuItem>
+              ))}
+            </Select>
+            <TextField
+              label="Review"
+              multiline
+              minRows={2}
+              value={review}
+              onChange={(e) => setReview(e.target.value)}
+              fullWidth
+            />
+            <TextField
+              label="Link"
+              value={link}
+              onChange={(e) => setLink(e.target.value)}
+              fullWidth
+            />
+            {error && <Alert severity="error">{error}</Alert>}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} disabled={loading} color="inherit">
+            Cancelar
+          </Button>
+          <Button type="submit" variant="contained" disabled={loading} startIcon={loading ? <CircularProgress size={18} /> : undefined}>
+            Salvar
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/src/components/dashboard/artifacts/artifact-card.tsx
+++ b/src/components/dashboard/artifacts/artifact-card.tsx
@@ -2,7 +2,6 @@
 import * as React from "react";
 import Avatar from "@mui/material/Avatar";
 import AvatarGroup from "@mui/material/AvatarGroup";
-import Box from "@mui/material/Box"; // Importado para usar Box para tags e ícones
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
@@ -14,38 +13,33 @@ import { Calendar as CalendarIcon } from "@phosphor-icons/react/dist/ssr/Calenda
 import { Flag as FlagIcon } from "@phosphor-icons/react/dist/ssr/Flag"; // Ícone de flag (prioridade)
 import { ChatCircle as ChatCircleIcon } from "@phosphor-icons/react/dist/ssr/ChatCircle"; // Ícone de chat
 
+const statusColorMap: Record<Artifact['status'], string> = {
+        draft: '#FFD700',
+        in_review: '#ADD8E6',
+        published: '#90EE90',
+};
+
 import type { Artifact } from "@/types/artifact";
 
 export interface ArtifactCardProps {
-	artifact: Artifact;
+        artifact: Artifact;
+        onClick?: (artifact: Artifact) => void;
 }
 
-export function ArtifactCard({ artifact }: ArtifactCardProps): React.JSX.Element {
-	// Mapeamento de cores para status (exemplo, ajuste conforme seu design)
-	const getStatusColor = (status: Artifact['status']): string => {
-		switch (status) {
-			case 'draft':
-				return '#FFD700'; // Amarelo
-			case 'in_review':
-				return '#ADD8E6'; // Azul claro
-			case 'published':
-				return '#90EE90'; // Verde claro
-			default:
-				return '#D3D3D3'; // Cinza claro
-		}
-	};
+export function ArtifactCard({ artifact, onClick }: ArtifactCardProps): React.JSX.Element {
 
-	return (
-		<Card sx={{
-			display: "flex",
-			flexDirection: "column",
-			height: "auto", // Altura automática para se ajustar ao conteúdo
-			borderRadius: 1, // Cantos mais arredondados
-			boxShadow: '0 1px 3px rgba(0,0,0,0.1)', // Sombra sutil
-			border: '1px solid #e0e0e0', // Borda sutil
-			p: 1.5, // Padding interno
-			backgroundColor: '#ffffff', // Fundo branco
-		}}>
+        return (
+                <Card onClick={() => onClick?.(artifact)} sx={{
+                        display: "flex",
+                        flexDirection: "column",
+                        height: "auto", // Altura automática para se ajustar ao conteúdo
+                        borderRadius: 1, // Cantos mais arredondados
+                        boxShadow: '0 1px 3px rgba(0,0,0,0.1)', // Sombra sutil
+                        border: '1px solid #e0e0e0', // Borda sutil
+                        p: 1.5, // Padding interno
+                        backgroundColor: '#ffffff', // Fundo branco
+                        cursor: onClick ? 'pointer' : 'default',
+                }}>
 			<CardContent sx={{ flex: "1 1 auto", p: 0, '&:last-child': { pb: 0 } }}> {/* Remover padding padrão do CardContent */}
 				<Stack spacing={1}>
 					{/* ID e Título */}
@@ -62,7 +56,7 @@ export function ArtifactCard({ artifact }: ArtifactCardProps): React.JSX.Element
 							label={artifact.status.replace('_', ' ').toUpperCase()} // Ex: DRAFT -> DRAFT
 							size="small"
 							sx={{
-								backgroundColor: getStatusColor(artifact.status),
+                                                                backgroundColor: statusColorMap[artifact.status] ?? '#D3D3D3',
 								color: 'rgba(0,0,0,0.87)',
 								fontWeight: 'bold',
 								height: '20px',


### PR DESCRIPTION
## Summary
- enable clicking artifact cards to edit their information
- manage selected artifact state on the dashboard
- add `EditArtifactModal` with form fields and API update call

## Testing
- `npm run lint` *(fails: unicorn/catch-error-name etc.)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686af2b62ff0832883fcacad7b61a570